### PR TITLE
Switch to unprivileged user for nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,5 +10,12 @@
 /build
 /js
 
+# Unnecessary docker-related files
 .dockerignore
+docker-compose*.yml
 Dockerfile
+
+# Unnecessary files for Docker image
+docs
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV REACT_APP_API_IMAGES /arasaac/images
 
 RUN yarn build:app
 
-FROM nginx:stable-alpine
+FROM nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=build /app/build /usr/share/nginx/html
 COPY config/nginx/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       context: .
     ports:
       - "8070:80"
+    restart: always


### PR DESCRIPTION
## Further Notes

- Reviewing the Dockerfile, I found that the production nginx container is using the root user; for the sake of best practices this should be avoided, see https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user

## New Features / Enhancements

- [x] Avoiding root user privileges for production docker image => increase security
- [x] Exclude unnecessary files from docker image => decrease docker image file size 

## After Merge Checklist