### PR TITLE
chore: Remove `autostart: always`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,3 @@ services:
       - "5173:5173"
     volumes:
       - .:/app
-    restart: always


### PR DESCRIPTION
This prevents the pictosearch container from starting once docker has launched.